### PR TITLE
CORE-8083: Process non-amqp errors better in amqpError

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,8 @@ func New(cfg *config.Config) *JEXAdapter {
 }
 
 func amqpError(err error) {
-	if err.(*amqp.Error).Code != 0 {
+	amqpErr, ok := err.(*amqp.Error)
+	if !ok || amqpErr.Code != 0 {
 		logcabin.Error.Fatal(err)
 	}
 }


### PR DESCRIPTION
I'm not really sure how to test this, but in the stacktrace the actual panic was that what it was getting passed wasn't an `*amqp.Error` but rather a `*net.OpError`. Then the panic got caught further up by the HTTP handling code. This should make it so that with a non-amqp error passed to the `amqpError` function it exits directly, like it already does when the code for an amqp error is nonzero.
