### PR TITLE
Switching to the apd.Decimal

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/cockroachdb/apd"
 	"github.com/cyverse-de/jex-adapter/logging"
 	"github.com/cyverse-de/jex-adapter/millicores"
 	"github.com/cyverse-de/jex-adapter/types"
@@ -90,7 +91,7 @@ func (a *AMQPMessenger) Launch(job *model.Job) error {
 type millicoresJob struct {
 	ID                 uuid.UUID
 	Job                model.Job
-	MillicoresReserved float64
+	MillicoresReserved *apd.Decimal
 }
 
 // JEXAdapter contains the application state for jex-adapter.
@@ -143,7 +144,7 @@ func (j *JEXAdapter) Run() {
 	}
 }
 
-func (j *JEXAdapter) StoreMillicoresReserved(job model.Job, millicoresReserved float64) error {
+func (j *JEXAdapter) StoreMillicoresReserved(job model.Job, millicoresReserved *apd.Decimal) error {
 	newjob := millicoresJob{
 		ID:                 uuid.New(),
 		Job:                job,

--- a/adapter/adapter_test.go
+++ b/adapter/adapter_test.go
@@ -51,7 +51,10 @@ func initTestAdapter(t *testing.T) (*JEXAdapter, sqlmock.Sqlmock) {
 		}
 		dbconn := sqlx.NewDb(mockconn, "postgres")
 		dbase := db.New(dbconn)
-		detector := millicores.New(dbase, 4000.0)
+		detector, err := millicores.New(dbase, 4000.0)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
 		a = New(cfg, detector, msger)
 	}
 	return a, mock

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/cockroachdb/apd v1.1.0
 	github.com/cyverse-de/configurate v0.0.0-20160830203814-4b85e07b4aea
 	github.com/cyverse-de/version v0.0.0-20160721234331-5119d6500655
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
+github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cyverse-de/configurate v0.0.0-20160830203814-4b85e07b4aea h1:vYlBrzIKegnCTm3XIjbeJfq0gF837X8ovghehxvzPGk=
 github.com/cyverse-de/configurate v0.0.0-20160830203814-4b85e07b4aea/go.mod h1:QMZ4G8bX5f0vKiH9+/2JqV687mN1byJ18tjZwIJIagI=
 github.com/cyverse-de/model v0.0.0-20160830212418-433e08f9889d h1:PIDb+UJlVX3+ctlt44as9cRBSCVyorn/qvaNdaqOjB0=

--- a/main.go
+++ b/main.go
@@ -131,7 +131,10 @@ func main() {
 	amqpclient, exchangeName := amqpConnection(cfg)
 
 	dbase := db.New(dbconn)
-	detector := millicores.New(dbase, *defaultMillicores)
+	detector, err := millicores.New(dbase, *defaultMillicores)
+	if err != nil {
+		log.Fatal(err)
+	}
 	messenger := adapter.NewAMQPMessenger(exchangeName, amqpclient)
 
 	p := previewer.New()


### PR DESCRIPTION
For consistency with upcoming app-exposer and resource-usage-api changes that do something similar, this will change the millicores_reserved logic over to use apd.Decimal instead of float64s. 